### PR TITLE
feat: add Content Management route with tabbed pages (Equations, Recipes, Library, Templates)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,7 +54,7 @@
         "react-router-dom": "^6.24.0",
         "react-scroll-parallax": "^3.4.2",
         "react-sortablejs": "^6.1.4",
-        "simplebar-react": "^3.2.4",
+        "simplebar-react": "^3.3.2",
         "sortablejs": "^1.15.0",
         "swiper": "^11.1.4",
         "yup": "^1.3.2"
@@ -1939,21 +1939,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.6.tgz",
-      "integrity": "sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "14.18.63",
@@ -6092,23 +6077,22 @@
       }
     },
     "node_modules/simplebar-core": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/simplebar-core/-/simplebar-core-1.2.6.tgz",
-      "integrity": "sha512-H5NYU+O+uvqOH5VXw3+lgoc1vTI6jL8LOZJsw4xgRpV7uIPjRpmLPdz0TrouxwKHBhpVLzVIlyKhaRLelIThMw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/simplebar-core/-/simplebar-core-1.3.2.tgz",
+      "integrity": "sha512-qKgTTuTqapjsFGkNhCjyPhysnbZGpQqNmjk0nOYjFN5ordC/Wjvg+RbYCyMSnW60l/Z0ZS82GbNltly6PMUH1w==",
       "license": "MIT",
       "dependencies": {
-        "@types/lodash-es": "^4.17.6",
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21"
       }
     },
     "node_modules/simplebar-react": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-3.2.6.tgz",
-      "integrity": "sha512-8jDiBuVCG86JmOrsmkA+4q77iFAEbhU9EX62PohLisg3dnxdLXFFhkxnx2Es3Cxt8IlZFlJsF9GaobFL3ukwiA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-3.3.2.tgz",
+      "integrity": "sha512-ZsgcQhKLtt5ra0BRIJeApfkTBQCa1vUPA/WXI4HcYReFt+oCEOvdVz6rR/XsGJcKxTlCRPmdGx1uJIUChupo+A==",
       "license": "MIT",
       "dependencies": {
-        "simplebar-core": "^1.2.6"
+        "simplebar-core": "^1.3.2"
       },
       "peerDependencies": {
         "react": ">=16.8.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "react-router-dom": "^6.24.0",
     "react-scroll-parallax": "^3.4.2",
     "react-sortablejs": "^6.1.4",
-    "simplebar-react": "^3.2.4",
+    "simplebar-react": "^3.3.2",
     "sortablejs": "^1.15.0",
     "swiper": "^11.1.4",
     "yup": "^1.3.2"

--- a/frontend/src/pages/admin/ContentManagement/ContentManagement.tsx
+++ b/frontend/src/pages/admin/ContentManagement/ContentManagement.tsx
@@ -1,0 +1,639 @@
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Tabs,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton,
+  Paper,
+  Pagination,
+  MenuItem,
+  Menu,
+  Chip,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Select,
+  FormControl,
+  InputLabel,
+  InputAdornment,
+  Switch,
+} from "@mui/material";
+import { Edit, Delete, Visibility, CloudUpload, Search } from "@mui/icons-material";
+import { ChevronDown } from "lucide-react";
+import {
+  Equation,
+  equations,
+  initialLibraryFiles,
+  initialTemplates,
+  LibraryFile,
+  Recipe,
+  recipes,
+  Template,
+} from "./index";
+
+// =====================
+// BasicMenu Component
+// =====================
+type BasicMenuProps = {
+  recipeId: number;
+  handleApproval: (id: number, val: boolean) => void;
+};
+
+const BasicMenu: React.FC<BasicMenuProps> = ({ recipeId, handleApproval }) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (decision?: boolean) => {
+    if (decision !== undefined) {
+      handleApproval(recipeId, decision);
+    }
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <Button
+        id="basic-button"
+        aria-controls={open ? "basic-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+        sx={{ minWidth: "40px" }}>
+        <ChevronDown />
+      </Button>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={() => handleClose()}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "center",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}>
+        <MenuItem onClick={() => handleClose(true)}>Approve</MenuItem>
+        <MenuItem onClick={() => handleClose(false)}>Reject</MenuItem>
+      </Menu>
+    </div>
+  );
+};
+// Main Component
+// =====================
+export default function ContentManagement() {
+  const [tab, setTab] = useState(0);
+  const [page, setPage] = useState(1);
+  const rowsPerPage = 8;
+
+  const [recipeState, setRecipeState] = useState<Recipe[]>(recipes);
+  const [libraryState, setLibraryState] = useState<LibraryFile[]>(initialLibraryFiles);
+  const [templatesState, setTemplatesState] = useState<Template[]>(initialTemplates);
+
+  // Library UI state
+  const [searchLib, setSearchLib] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<"All" | string>("All");
+  const [TagsFilter, setTagsFilter] = useState<"All" | string>("All");
+  const [openUpload, setOpenUpload] = useState(false);
+  const [newFileName, setNewFileName] = useState("");
+  const [newFileCategory, setNewFileCategory] = useState("Meal Plan");
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+
+  // Templates UI state
+  const [searchTemplate, setSearchTemplate] = useState("");
+  const [CategoryTFilter, setCategoryTFilter] = useState("All");
+  const [openTemplateDialog, setOpenTemplateDialog] = useState(false);
+  const [newTemplateName, setNewTemplateName] = useState("");
+  const [newTemplateCalories, setNewTemplateCalories] = useState("");
+  const [newTemplateCategory, setNewTemplateCategory] = useState("Meal Plan");
+
+  const handleApproval = (id: number, val: boolean) => {
+    setRecipeState((prev) => prev.map((r) => (r.id === id ? { ...r, request: val ? "Approved" : "Rejected" } : r)));
+  };
+
+  const filteredLibrary = libraryState.filter((f) => {
+    const matchesCategory = categoryFilter === "All" || f.category === categoryFilter;
+    const q = searchLib.trim().toLowerCase();
+    const matchesSearch =
+      q === "" ||
+      f.name.toLowerCase().includes(q) ||
+      f.type.toLowerCase().includes(q) ||
+      f.category.toLowerCase().includes(q);
+    return matchesCategory && matchesSearch;
+  });
+
+  const filteredTemplates = templatesState.filter((t) => {
+    const q = searchTemplate.trim().toLowerCase();
+    const matchesSearch =
+      q === "" ||
+      t.name.toLowerCase().includes(q) ||
+      t.category.toLowerCase().includes(q) ||
+      t.calories.toLowerCase().includes(q);
+    const matchesCategory = CategoryTFilter === "All" || t.category === CategoryTFilter;
+    return matchesSearch && matchesCategory;
+  });
+
+  const data = tab === 0 ? equations : tab === 1 ? recipeState : tab === 2 ? filteredLibrary : filteredTemplates;
+
+  const totalPages = Math.max(1, Math.ceil(data.length / rowsPerPage));
+  const startIndex = (page - 1) * rowsPerPage;
+  const currentRows = data.slice(startIndex, startIndex + rowsPerPage);
+
+  useEffect(() => {
+    if (tab === 2 || tab === 3) setPage(1);
+  }, [searchLib, categoryFilter, searchTemplate, CategoryTFilter, tab]);
+
+  const handleChangePage = (_: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+  };
+
+  const handleUpload = () => {
+    if (!newFileName && !uploadedFile) {
+      setOpenUpload(false);
+      return;
+    }
+    const fileName = newFileName || uploadedFile?.name || "New File";
+    const fileType = uploadedFile ? uploadedFile.name.split(".").pop()?.toUpperCase() || "FILE" : "FILE";
+
+    setLibraryState((prev) => [
+      {
+        id: prev.length + 1,
+        name: fileName,
+        type: fileType,
+        category: newFileCategory,
+      },
+      ...prev,
+    ]);
+
+    setNewFileName("");
+    setUploadedFile(null);
+    setNewFileCategory("Meal Plan");
+    setOpenUpload(false);
+    if (tab === 2) setPage(1);
+  };
+
+  // const handleAddTemplate = () => {
+  //   if (!newTemplateName || !newTemplateCalories) {
+  //     setOpenTemplateDialog(false);
+  //     return;
+  //   }
+
+  //   setTemplatesState((prev) => [
+  //     {
+  //       id: prev.length + 1,
+  //       name: newTemplateName,
+  //       calories: newTemplateCalories,
+  //       category: newTemplateCategory,
+  //       active: true,
+  //     },
+  //     ...prev,
+  //   ]);
+
+  //   setNewTemplateName("");
+  //   setNewTemplateCalories("");
+  //   setNewTemplateCategory("Meal Plan");
+  //   setOpenTemplateDialog(false);
+  //   if (tab === 3) setPage(1);
+  // };
+
+  return (
+    <>
+      <h2 className="pt-0">Content Management</h2>
+
+      <Box sx={{ width: "100%" }}>
+        {/* Tabs */}
+        <Tabs
+          value={tab}
+          onChange={(_, v) => {
+            setTab(v);
+            setPage(1);
+          }}
+          variant="fullWidth"
+          TabIndicatorProps={{ style: { display: "none" } }}
+          sx={{
+            "& .MuiTab-root": {
+              textTransform: "none",
+              fontWeight: 500,
+              minHeight: "40px",
+              backgroundColor: "#f5f5f5",
+            },
+            "& .Mui-selected": {
+              bgcolor: (theme) => theme.palette.primary.main,
+              color: "white !important",
+              borderRadius: "8px",
+            },
+          }}>
+          <Tab label="Equation" />
+          <Tab label="Recipe" />
+          <Tab label="Library" />
+          <Tab label="Templates" />
+        </Tabs>
+
+        {/* Controls */}
+        <Box display="flex" justifyContent="flex-end" mt={2} mb={3} gap={2} alignItems="center">
+          {tab === 2 && (
+            <>
+              <TextField
+                size="small"
+                placeholder="Search files"
+                value={searchLib}
+                onChange={(e) => setSearchLib(e.target.value)}
+                sx={{ width: 220 }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <Search />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+
+              <FormControl size="small" sx={{ minWidth: 160 }}>
+                <InputLabel id="lib-category-label">Category</InputLabel>
+                <Select
+                  labelId="lib-category-label"
+                  value={categoryFilter}
+                  label="Category"
+                  onChange={(e) => setCategoryFilter(e.target.value)}>
+                  <MenuItem value="All">All</MenuItem>
+                  <MenuItem value="Meal Plan">Meal Plan</MenuItem>
+                  <MenuItem value="Workout Plan">Workout Plan</MenuItem>
+                  <MenuItem value="General">General</MenuItem>
+                </Select>
+              </FormControl>
+
+              <FormControl size="small" sx={{ minWidth: 160 }}>
+                <InputLabel id="lib-tags-label">Tags</InputLabel>
+                <Select
+                  labelId="lib-tags-label"
+                  value={TagsFilter}
+                  label="Tags"
+                  onChange={(e) => setTagsFilter(e.target.value)}>
+                  <MenuItem value="All">All</MenuItem>
+                  <MenuItem value="Tag 1">Tag 1</MenuItem>
+                  <MenuItem value="Tag 2">Tag 2</MenuItem>
+                  <MenuItem value="Tag 3">Tag 3</MenuItem>
+                </Select>
+              </FormControl>
+            </>
+          )}
+
+          {tab === 3 && (
+            <>
+              <TextField
+                size="small"
+                placeholder="Search by name"
+                value={searchTemplate}
+                onChange={(e) => setSearchTemplate(e.target.value)}
+                sx={{ width: 220 }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <Search />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+              <FormControl size="small" sx={{ minWidth: 160 }}>
+                <InputLabel id="lib-categoryT-label">Category</InputLabel>
+                <Select
+                  labelId="lib-categoryT-label"
+                  value={CategoryTFilter}
+                  label="CategoryT"
+                  onChange={(e) => setCategoryTFilter(e.target.value)}>
+                  <MenuItem value="All">All</MenuItem>
+                  <MenuItem value="Meal Plan">Meal Plan</MenuItem>
+                  <MenuItem value="Workout Plan">Workout Plan</MenuItem>
+                  <MenuItem value="General">General</MenuItem>
+                </Select>
+              </FormControl>
+            </>
+          )}
+
+          <Button
+            variant="contained"
+            onClick={() => (tab === 2 ? setOpenUpload(true) : null)}
+            sx={{
+              bgcolor: (theme) => theme.palette.primary.main,
+              "&:hover": { bgcolor: (theme) => theme.palette.secondary.main },
+              borderRadius: "8px",
+              textTransform: "none",
+              fontWeight: 600,
+            }}>
+            {tab === 0
+              ? "Create New Equation"
+              : tab === 1
+                ? "Recipe Requests"
+                : tab === 2
+                  ? "Upload New File"
+                  : "Create New Templates"}
+          </Button>
+        </Box>
+
+        {/* Table */}
+        <Box>
+          <TableContainer
+            component={Paper}
+            sx={{
+              boxShadow: "none",
+              borderRadius: "10px 10px 0 0",
+              border: "0.5px solid",
+              borderColor: (theme) => theme.palette.primary.main,
+              borderBottom: "none",
+            }}>
+            <Table
+              size="small"
+              sx={{
+                borderCollapse: "collapse",
+                "& td, & th": {
+                  border: "0.5px solid",
+                  borderColor: (theme) => theme.palette.primary.main,
+                  fontSize: "13px",
+                },
+                "& td:first-of-type, & th:first-of-type": {
+                  borderLeft: "none",
+                },
+                "& td:last-of-type, & th:last-of-type": {
+                  borderRight: "none",
+                },
+              }}>
+              <TableHead>
+                <TableRow sx={{ bgcolor: (theme) => theme.palette.primary.main, height: "50px" }}>
+                  {tab === 0 &&
+                    ["Name of Equation", "Equation", "Input", "Units", "Actions"].map((head) => (
+                      <TableCell key={head} sx={{ color: "white", fontWeight: 600 }}>
+                        {head}
+                      </TableCell>
+                    ))}
+                  {tab === 1 &&
+                    ["Recipe Name", "Calories", "Published By", "Complete Recipe", "Request", "Actions"].map((head) => (
+                      <TableCell key={head} sx={{ color: "white", fontWeight: 600 }}>
+                        {head}
+                      </TableCell>
+                    ))}
+                  {tab === 2 &&
+                    ["File Name", "File Type", "Category", "Actions"].map((head) => (
+                      <TableCell key={head} sx={{ color: "white", fontWeight: 600 }}>
+                        {head}
+                      </TableCell>
+                    ))}
+                  {tab === 3 &&
+                    ["Name", "Calories", "Category", "Visibility"].map((head) => (
+                      <TableCell key={head} sx={{ color: "white", fontWeight: 600 }}>
+                        {head}
+                      </TableCell>
+                    ))}
+                </TableRow>
+              </TableHead>
+
+              <TableBody>
+                {/* Equations */}
+                {tab === 0 &&
+                  (currentRows as Equation[]).map((eq) => (
+                    <TableRow key={eq.id} hover>
+                      <TableCell>{eq.name}</TableCell>
+                      <TableCell>{eq.equation}</TableCell>
+                      <TableCell>{eq.input}</TableCell>
+                      <TableCell>{eq.units}</TableCell>
+                      <TableCell>
+                        <IconButton color="success">
+                          <Edit />
+                        </IconButton>
+                        <IconButton color="error">
+                          <Delete />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+
+                {/* Recipes */}
+                {tab === 1 &&
+                  (currentRows as Recipe[]).map((recipe) => (
+                    <TableRow key={recipe.id} hover>
+                      <TableCell>{recipe.name}</TableCell>
+                      <TableCell>{recipe.calories}</TableCell>
+                      <TableCell>{recipe.publishedBy}</TableCell>
+                      <TableCell>
+                        <IconButton color="success">
+                          <Visibility />
+                        </IconButton>
+                      </TableCell>
+                      <TableCell>
+                        {recipe.request === "Pending" ? (
+                          <BasicMenu recipeId={recipe.id} handleApproval={handleApproval} />
+                        ) : recipe.request === "Approved" ? (
+                          <Chip
+                            label="Approved"
+                            size="small"
+                            sx={{
+                              borderRadius: "8px",
+                              color: (theme) => theme.palette.primary.main,
+                              fontWeight: "bold",
+                            }}
+                          />
+                        ) : recipe.request === "Rejected" ? (
+                          <Chip
+                            label="Rejected"
+                            size="small"
+                            sx={{
+                              borderRadius: "8px",
+                              bgcolor: "red",
+                              color: "white",
+                              fontWeight: "bold",
+                            }}
+                          />
+                        ) : null}
+                      </TableCell>
+                      <TableCell>
+                        <IconButton color="success">
+                          <Edit />
+                        </IconButton>
+                        <IconButton color="error">
+                          <Delete />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+
+                {/* Library */}
+                {tab === 2 &&
+                  (currentRows as LibraryFile[]).map((file) => (
+                    <TableRow key={file.id} hover>
+                      <TableCell>{file.name}</TableCell>
+                      <TableCell>{file.type}</TableCell>
+                      <TableCell>{file.category}</TableCell>
+                      <TableCell>
+                        <IconButton color="success">
+                          <Edit />
+                        </IconButton>
+                        <IconButton color="error">
+                          <Delete />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+
+                {/* Templates */}
+                {tab === 3 &&
+                  (currentRows as Template[]).map((t) => (
+                    <TableRow key={t.id} hover>
+                      <TableCell>{t.name}</TableCell>
+                      <TableCell>{t.calories}</TableCell>
+                      <TableCell>{t.category}</TableCell>
+                      <TableCell>
+                        <Switch
+                          checked={t.active}
+                          onChange={() =>
+                            setTemplatesState((prev) =>
+                              prev.map((item) => (item.id === t.id ? { ...item, active: !item.active } : item)),
+                            )
+                          }
+                          color="success"
+                        />
+                        {t.active ? "Active" : "Inactive"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          {/* Pagination */}
+          <Box
+            sx={{
+              border: "1px solid",
+              borderTop: "none",
+              borderBottomLeftRadius: "10px",
+              borderBottomRightRadius: "10px",
+              borderColor: (theme) => theme.palette.primary.main,
+              p: 1,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}>
+            <Button
+              variant="text"
+              onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+              disabled={page === 1}
+              sx={{
+                minWidth: "40px",
+                border: "1px solid rgb(227, 227, 227)",
+                borderRadius: "10px",
+                bgcolor: "white",
+              }}>
+              &lt;
+            </Button>
+
+            <Pagination
+              count={totalPages}
+              page={page}
+              onChange={handleChangePage}
+              color="primary"
+              hidePrevButton
+              hideNextButton
+              sx={{
+                "& .MuiPaginationItem-root": {
+                  borderRadius: "8px",
+                  color: (theme) => theme.palette.primary.main,
+                  fontSize: "12px",
+                },
+                "& .Mui-selected": {
+                  bgcolor: (theme) => theme.palette.primary.main + " !important",
+                  color: "white",
+                },
+              }}
+            />
+
+            <Button
+              variant="text"
+              onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
+              disabled={page === totalPages}
+              sx={{
+                minWidth: "40px",
+                border: "1px solid rgb(227, 227, 227)",
+                borderRadius: "10px",
+                bgcolor: "white",
+              }}>
+              &gt;
+            </Button>
+          </Box>
+        </Box>
+
+        {/* Upload Dialog (Library) */}
+        <Dialog open={openUpload} onClose={() => setOpenUpload(false)} maxWidth="sm" fullWidth>
+          <DialogTitle>File Upload</DialogTitle>
+          <DialogContent>
+            <Box
+              sx={{
+                border: "2px dashed #ccc",
+                borderRadius: "8px",
+                p: 4,
+                textAlign: "center",
+                mb: 3,
+                cursor: "pointer",
+                transition: "0.2s",
+                "&:hover": { borderColor: "#1976d2", backgroundColor: "#f9f9f9" },
+              }}
+              onClick={() => document.getElementById("fileInput")?.click()}>
+              <CloudUpload fontSize="large" color="action" />
+              <p>Click or drag file to this area to upload</p>
+              <input
+                id="fileInput"
+                hidden
+                type="file"
+                onChange={(e) => {
+                  if (e.target.files && e.target.files.length > 0) {
+                    setUploadedFile(e.target.files[0]);
+                    setNewFileName(e.target.files[0].name);
+                  }
+                }}
+              />
+            </Box>
+
+            <TextField
+              fullWidth
+              label="File name"
+              value={newFileName}
+              onChange={(e) => setNewFileName(e.target.value)}
+              sx={{ mb: 2 }}
+            />
+
+            <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+              <InputLabel>Category</InputLabel>
+              <Select value={newFileCategory} label="Category" onChange={(e) => setNewFileCategory(e.target.value)}>
+                <MenuItem value="Meal Plan">Meal Plan</MenuItem>
+                <MenuItem value="Workout Plan">Workout Plan</MenuItem>
+                <MenuItem value="General">General</MenuItem>
+              </Select>
+            </FormControl>
+
+            <Box display="flex" justifyContent="space-between" mt={2}>
+              <Button variant="outlined" onClick={() => setOpenUpload(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="contained"
+                sx={{ bgcolor: (theme) => theme.palette.primary.main }}
+                onClick={handleUpload}>
+                Continue
+              </Button>
+            </Box>
+          </DialogContent>
+        </Dialog>
+      </Box>
+    </>
+  );
+}

--- a/frontend/src/pages/admin/ContentManagement/index.ts
+++ b/frontend/src/pages/admin/ContentManagement/index.ts
@@ -1,0 +1,64 @@
+export interface Equation {
+  id: number;
+  equation: string;
+  name: string;
+  input: string;
+  units: string;
+}
+
+export interface Recipe {
+  id: number;
+  name: string;
+  calories: string;
+  publishedBy: string;
+  request: "Approved" | "Rejected" | "Pending" | "";
+}
+
+export interface LibraryFile {
+  id: number;
+  name: string;
+  type: string;
+  category: string;
+}
+
+export interface Template {
+  id: number;
+  name: string;
+  calories: string;
+  category: string;
+  active: boolean;
+}
+
+// =====================
+// Dummy Data
+// =====================
+export const equations: Equation[] = Array.from({ length: 28 }, (_, i) => ({
+  id: i + 1,
+  name: "Body Mass Index (BMI)",
+  equation: "Weight / H² (height in meter)",
+  input: "Weight",
+  units: "Kg/m²",
+}));
+
+export const recipes: Recipe[] = Array.from({ length: 23 }, (_, i) => ({
+  id: i + 1,
+  name: "Zesty Lemon Herb Chicken",
+  calories: "330 kcal",
+  publishedBy: i % 2 === 0 ? "By Admin" : "By Community",
+  request: i % 3 === 0 ? "Approved" : i % 3 === 1 ? "Rejected" : "Pending",
+}));
+
+export const initialLibraryFiles: LibraryFile[] = Array.from({ length: 25 }, (_, i) => ({
+  id: i + 1,
+  name: i === 0 ? "Healthy Diet" : `File ${i + 1}`,
+  type: i === 0 ? "PDF" : "DOCX",
+  category: i % 3 === 0 ? "Meal Plan" : i % 3 === 1 ? "Workout Plan" : "General",
+}));
+
+export const initialTemplates: Template[] = Array.from({ length: 28 }, (_, i) => ({
+  id: i + 1,
+  name: "Sample Content Name",
+  calories: "1200 kcal",
+  category: i % 3 === 0 ? "Meal Plan" : i % 3 === 1 ? "Workout Plan" : "General",
+  active: true,
+}));

--- a/frontend/src/pages/auth/Login/useLogin.ts
+++ b/frontend/src/pages/auth/Login/useLogin.ts
@@ -34,13 +34,18 @@ export default function useLogin() {
   type LoginFormFields = yup.InferType<typeof loginFormSchema>;
 
   const redirectUrl = useMemo(() => {
-    // If there's a specific redirect path from location state, use it
-    if (location.state?.from?.pathname) {
-      return location.state.from.pathname;
-    }
-    // Otherwise redirect to the dashboard
-    return "/ecommerce";
-  }, [location.state]);
+  const fromPath = location.state?.from?.pathname;
+
+  if (fromPath) {
+    return fromPath.startsWith("/admin") ? "/admin/user" : fromPath;
+  }
+
+  if (location.pathname.startsWith("/admin")) {
+    return "/admin/user";
+  }
+
+  return "/ecommerce";
+}, [location.state, location.pathname]);
 
   const login = handleSubmit(async (values: LoginFormFields) => {
     setLoading(true);

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -147,6 +147,7 @@ const adminRoutes: RoutesProps[] = [
 
 const adminDashboardRoutes: RoutesProps[] = [
   { path: "/admin/user", element: <LoadComponent component={lazy(() => import("@src/pages/admin/dashboard/UserManagement"))} /> },
+  { path: "/admin/content-management", element: <LoadComponent component={lazy(() => import("@src/pages/admin/ContentManagement/ContentManagement"))} /> },
 ]
 
 export const defaultLayoutRoutes = [

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -786,18 +786,6 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/lodash-es@^4.17.6":
-  version "4.17.12"
-  resolved "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz"
-  integrity sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.17.6"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.6.tgz"
-  integrity sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==
-
 "@types/node@^14.0.1", "@types/node@>= 14":
   version "14.18.63"
   resolved "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz"
@@ -3167,21 +3155,20 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-simplebar-core@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.npmjs.org/simplebar-core/-/simplebar-core-1.2.6.tgz"
-  integrity sha512-H5NYU+O+uvqOH5VXw3+lgoc1vTI6jL8LOZJsw4xgRpV7uIPjRpmLPdz0TrouxwKHBhpVLzVIlyKhaRLelIThMw==
+simplebar-core@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/simplebar-core/-/simplebar-core-1.3.2.tgz"
+  integrity sha512-qKgTTuTqapjsFGkNhCjyPhysnbZGpQqNmjk0nOYjFN5ordC/Wjvg+RbYCyMSnW60l/Z0ZS82GbNltly6PMUH1w==
   dependencies:
-    "@types/lodash-es" "^4.17.6"
     lodash "^4.17.21"
     lodash-es "^4.17.21"
 
-simplebar-react@^3.2.4:
-  version "3.2.6"
-  resolved "https://registry.npmjs.org/simplebar-react/-/simplebar-react-3.2.6.tgz"
-  integrity sha512-8jDiBuVCG86JmOrsmkA+4q77iFAEbhU9EX62PohLisg3dnxdLXFFhkxnx2Es3Cxt8IlZFlJsF9GaobFL3ukwiA==
+simplebar-react@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/simplebar-react/-/simplebar-react-3.3.2.tgz"
+  integrity sha512-ZsgcQhKLtt5ra0BRIJeApfkTBQCa1vUPA/WXI4HcYReFt+oCEOvdVz6rR/XsGJcKxTlCRPmdGx1uJIUChupo+A==
   dependencies:
-    simplebar-core "^1.2.6"
+    simplebar-core "^1.3.2"
 
 slash@^3.0.0:
   version "3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,100 @@
+{
+  "name": "Nutricare",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@hookform/resolvers": "^5.2.1",
+        "yup": "^1.7.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.0.tgz",
+      "integrity": "sha512-VJce62dBd+JQvoc+fCVq+KZfPHr+hXaxCcVgotfwWvlR0Ja3ffYKaJBT8rptPOSKOGJDCUnW2C2JWpud7aRP6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
+    "yup": "^1.7.0"
+  }
+}


### PR DESCRIPTION
### Overview
Added a new `content-management` route with a main `ContentManagement` page.
The page is divided into 4 main tabs, each handling different types of content.

### Details
- **Equations Tab**
  - Table with columns: Name of Equation, Equation, Input, Units, Actions
  - Button: "Create New Equation"

- **Recipes Tab**
  - Table with columns: Recipe Name, Calories, Published By, Complete Recipe (eye icon), Request (dropdown for Approved/Rejected), Actions
  - Button: "Recipe Requests"

- **Library Tab**
  - Table with columns: File Name, File Type, Category, Actions
  - Category dropdown filter
  - Tags dropdown filter
  - Search functionality by file name
  - Button: "Upload File"

- **Templates Tab**
  - Table with columns: Name, Calories, Category, Visibility (active/inactive with switch)
  - Search functionality by name
  - Category dropdown filter
  - Button: "Create New Template"

### Notes
- All tabs include pagination and maintain consistent design using MUI components.
- Added `BasicMenu` for handling recipe approval/rejection dropdown.
- Implemented mock data for each tab (Equations, Recipes, Library Files, Templates).
